### PR TITLE
Remove unecessary order allow directive

### DIFF
--- a/conf/vhost/git_smart_http.conf
+++ b/conf/vhost/git_smart_http.conf
@@ -9,9 +9,6 @@ ScriptAlias /git/ "_GIT_HTTP_BACKEND_"
   ErrorDocument 401 default
   ErrorDocument 403 default
   ErrorDocument 404 default
-  
-  Order allow,deny
-  Allow from all
 
   AuthType Basic
   AuthName "OpenProject GIT"


### PR DESCRIPTION
Should get rid of the following error output:

```
Nov 19 11:46:31 ip-10-0-0-36 start_apache2[15578]: AH00526: Syntax error on line 13 of /etc/openproject/addons/apache2/includes/vhost/git_smart_http.conf:
Nov 19 11:46:31 ip-10-0-0-36 start_apache2[15578]: Invalid command 'Order', perhaps misspelled or defined by a module not included in the server configuration
```

/cc @crohr 
