### PR TITLE
Fix/config issues

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -259,6 +259,9 @@ SERVER_CONF
 }
 
 install_apache_configuration() {
+	${CLI} config:set SVN_REPOSITORIES=""
+	${CLI} config:set GIT_REPOSITORIES=""
+
 	if vendor_selected "svn" || vendor_selected "git"; then
 		configure_apache2_server
 		add_openproject_to_apache_group

--- a/bin/preinstall
+++ b/bin/preinstall
@@ -38,6 +38,8 @@ install_required_dependencies_for_apache2() {
 				wiz_check_package "$dependency" || zypper install -y "$dependency"
 			done
 
+			wiz_set "repositories/git-http-backend" "/usr/lib/git/git-http-backend"
+
 			a2enmod perl
 			a2enmod dav
 			a2enmod dav_svn


### PR DESCRIPTION
1. Reset repositories path when setting up repositories …

Otherwise, the installer will pick up previous configurations and set up
repository integration, even though it's been skipped.
1. Fix SLES git-http-backend path

On SLES (tested on 12) , the correct `git-http-backend` path is `/usr/lib/git/git-http-backend`.
